### PR TITLE
feature: burger menu now closes when clicked outside of it; introduction of BurgerMenu class

### DIFF
--- a/burgerMenu.js
+++ b/burgerMenu.js
@@ -1,0 +1,58 @@
+const CSS_CLASSES = Object.freeze({
+  MENU_LINKS_DIV: 'menu-links',
+  HAMBURGER_ICON_DIV: 'hamburger-icon',
+  HAMBURGER_MENU: 'hamburger-menu',
+  OPEN_MENU: 'open',
+});
+
+class BurgerMenu {
+  /** @type {HTMLDivElement} */
+  menu;
+  /** @type {HTMLDivElement} */
+  icon;
+  constructor() {
+    this.menu = document.querySelector(`.${CSS_CLASSES.MENU_LINKS_DIV}`);
+    this.icon = document.querySelector(`.${CSS_CLASSES.HAMBURGER_ICON_DIV}`);
+
+    window.addEventListener('click', this.#onBlurListener.bind(this));
+  }
+  
+  /**
+   * Describes if the burger menu is open.
+   * @returns {boolean}
+  */
+  isOpen() {
+    return this.menu.classList.contains(CSS_CLASSES.OPEN_MENU);
+  }
+
+  /** Method used to open the burger menu. */
+  open() {
+    this.menu.classList.add(CSS_CLASSES.OPEN_MENU)
+    this.menu.classList.add(CSS_CLASSES.OPEN_MENU)
+  }
+  
+  /** Method used to close the burger menu. */
+  close() {
+    this.menu.classList.remove(CSS_CLASSES.OPEN_MENU);
+    this.icon.classList.remove(CSS_CLASSES.OPEN_MENU);
+  }
+  
+  /** Method used to toggle the burger menu open/closed state. */
+  toggle() {
+    if (this.isOpen()) return this.close();
+    this.open();
+  }
+  
+  /**
+   * Callback used to close the burger menu when users clicks outside of it.
+   * By default when something inside the menu is clicked, the menu remains open.
+   * It allows for nesting of inputs and buttons with custom logic.
+   * @param {MouseEvent} event
+   */
+  #onBlurListener(event) {
+    const menuLinksDiv = event.composedPath().find(element => element.classList?.contains(CSS_CLASSES.HAMBURGER_MENU));
+    if (!menuLinksDiv) return this.close();
+  }
+};
+
+var burgerMenu = new BurgerMenu();

--- a/index.html
+++ b/index.html
@@ -24,16 +24,16 @@
     <nav id="hamburger-nav">
       <div class="logo">Zishan Pathan</div>
       <div class="hamburger-menu">
-        <div class="hamburger-icon" onclick="toggleMenu()">
+        <div class="hamburger-icon" onclick="burgerMenu.toggle()">
           <span></span>
           <span></span>
           <span></span>
         </div>
         <div class="menu-links">
-          <li><a href="#about" onclick="toggleMenu()">About</a></li>
-          <li><a href="#experience" onclick="toggleMenu()">Experience</a></li>
-          <li><a href="#projects" onclick="toggleMenu()">Projects</a></li>
-          <li><a href="#contact" onclick="toggleMenu()">Contact</a></li>
+          <li><a href="#about" onclick="burgerMenu.close()">About</a></li>
+          <li><a href="#experience" onclick="burgerMenu.close()">Experience</a></li>
+          <li><a href="#projects" onclick="burgerMenu.close()">Projects</a></li>
+          <li><a href="#contact" onclick="burgerMenu.close()">Contact</a></li>
         </div>
       </div>
     </nav>
@@ -453,6 +453,7 @@
       <p>Copyright &#169; 2023 zishan-pathan. All Rights Reserved.</p>
     </footer>
 
+    <script src="burgerMenu.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,0 @@
-function toggleMenu() {
-  const menu = document.querySelector(".menu-links");
-  const icon = document.querySelector(".hamburger-icon");
-  menu.classList.toggle("open");
-  icon.classList.toggle("open");
-}


### PR DESCRIPTION
Hi! **I have seen that your burger menu stays open after clicking outside of it.**

I created the `BurgerMenu` class with some methods such as `isOpen`, `open`, `close` and `toggle` for easier future improvements. Apart from that I implemented automatic closing on click outside of it. When you click inside of the open burger menu, it stays open as previously, so it still allows for inserting some inputs or checkboxes inside of it. Also, I used some JSDoc comments, which provide convenient IDE suggestions.

It would be great if you would like to merge these changes!

![image](https://github.com/zishanPathan/Portfolio/assets/78451054/d886621c-d761-4ee4-acc8-fcca3f8a8bae)
